### PR TITLE
[Issue #52] resolve void pointer arithmetic error by adding explicit type casts

### DIFF
--- a/pixels-core/lib/reader/IntegerColumnReader.cpp
+++ b/pixels-core/lib/reader/IntegerColumnReader.cpp
@@ -4,7 +4,8 @@
 
 #include "reader/IntegerColumnReader.h"
 
-IntegerColumnReader::IntegerColumnReader(std::shared_ptr<TypeDescription> type) : ColumnReader(type) {
+IntegerColumnReader::IntegerColumnReader(std::shared_ptr<TypeDescription> type)
+    : ColumnReader(type) {
     isLong = false;
     // TODO: implement
 }
@@ -13,20 +14,24 @@ void IntegerColumnReader::close() {
     // TODO: implement
 }
 
-void IntegerColumnReader::read(std::shared_ptr<ByteBuffer> input, pixels::proto::ColumnEncoding & encoding, int offset,
-                               int size, int pixelStride, int vectorIndex, std::shared_ptr<ColumnVector> vector,
-                               pixels::proto::ColumnChunkIndex & chunkIndex, std::shared_ptr<PixelsBitMask> filterMask) {
+void IntegerColumnReader::read(std::shared_ptr<ByteBuffer> input,
+                               pixels::proto::ColumnEncoding &encoding,
+                               int offset, int size, int pixelStride,
+                               int vectorIndex,
+                               std::shared_ptr<ColumnVector> vector,
+                               pixels::proto::ColumnChunkIndex &chunkIndex,
+                               std::shared_ptr<PixelsBitMask> filterMask) {
     std::shared_ptr<LongColumnVector> columnVector =
-            std::static_pointer_cast<LongColumnVector>(vector);
+        std::static_pointer_cast<LongColumnVector>(vector);
 
     // Make sure [offset, offset + size) is in the same pixels.
     assert(offset / pixelStride == (offset + size - 1) / pixelStride);
 
     // if read from start, init the stream and decoder
-    if(offset == 0) {
+    if (offset == 0) {
         decoder = std::make_shared<RunLenIntDecoder>(input, true);
         ColumnReader::elementIndex = 0;
-		isLong = type->getCategory() == TypeDescription::Category::LONG;
+        isLong = type->getCategory() == TypeDescription::Category::LONG;
         isNullOffset = chunkIndex.isnulloffset();
     }
 
@@ -35,24 +40,29 @@ void IntegerColumnReader::read(std::shared_ptr<ByteBuffer> input, pixels::proto:
     bool hasNull = chunkIndex.pixelstatistics(pixelId).statistic().hasnull();
     setValid(input, pixelStride, vector, pixelId, hasNull);
 
-    if(encoding.kind() == pixels::proto::ColumnEncoding_Kind_RUNLENGTH) {
-        for(int i = 0; i < size; i++) {
-			if(isLong) {
-				columnVector->longVector[i + vectorIndex] = decoder->next();
-			} else {
-				*(reinterpret_cast<int*>(columnVector->intVector) + i + vectorIndex)  = decoder->next();
-			}
+    if (encoding.kind() == pixels::proto::ColumnEncoding_Kind_RUNLENGTH) {
+        for (int i = 0; i < size; i++) {
+            if (isLong) {
+                columnVector->longVector[i + vectorIndex] = decoder->next();
+            } else {
+                *(reinterpret_cast<int *>(columnVector->intVector) + i +
+                  vectorIndex) = decoder->next();
+            }
             elementIndex++;
         }
     } else {
-        if(isLong) {
-            // if long
-            std::memcpy((void*)columnVector->longVector + vectorIndex * sizeof(int64_t), input->getPointer() + input->getReadPos(), size * sizeof(int64_t));
-			input->setReadPos(input->getReadPos() + size * sizeof(int64_t));
+        if (isLong) {
+            std::memcpy(reinterpret_cast<int64_t *>(columnVector->longVector) +
+                            vectorIndex,
+                        input->getPointer() + input->getReadPos(),
+                        size * sizeof(int64_t));
+            input->setReadPos(input->getReadPos() + size * sizeof(int64_t));
         } else {
             // if int
-            std::memcpy((void*)columnVector->intVector + vectorIndex * sizeof(int), input->getPointer() + input->getReadPos(), size * sizeof(int));
-			input->setReadPos(input->getReadPos() + size * sizeof(int));
+            std::memcpy(
+                reinterpret_cast<int *>(columnVector->intVector) + vectorIndex,
+                input->getPointer() + input->getReadPos(), size * sizeof(int));
+            input->setReadPos(input->getReadPos() + size * sizeof(int));
         }
     }
 }


### PR DESCRIPTION
Explicitly cast `void*` to `int64_t*` and `int*` to ensure pointer arithmetic is valid. This improves compatibility with Clang, which strictly disallows arithmetic on `void*`.

Fixes #52