### PR TITLE
[Issue #60] make the constructors of Date/TimestampColumnWriter public

### DIFF
--- a/pixels-core/include/writer/DateColumnWriter.h
+++ b/pixels-core/include/writer/DateColumnWriter.h
@@ -29,6 +29,7 @@
 #include "encoding/RunLenIntEncoder.h"
 
 class DateColumnWriter : public ColumnWriter{
+public:
     DateColumnWriter(std::shared_ptr<TypeDescription> type, std::shared_ptr<PixelsWriterOption> writerOption);
 
     int write(std::shared_ptr<ColumnVector> vector, int length) override;

--- a/pixels-core/include/writer/TimestampColumnWriter.h
+++ b/pixels-core/include/writer/TimestampColumnWriter.h
@@ -28,6 +28,7 @@
 #include "encoding/RunLenIntEncoder.h"
 
 class TimestampColumnWriter : public ColumnWriter{
+public:
     TimestampColumnWriter(std::shared_ptr<TypeDescription> type, std::shared_ptr<PixelsWriterOption> writerOption);
 
     int write(std::shared_ptr<ColumnVector> vector, int length) override;


### PR DESCRIPTION
Correct DateColumnWriter and TimestampColumnWriter classes by adding public access specifier.

Close #60 