### PR TITLE
[Issue #62] add const for getColumnChunkEncoding

### DIFF
--- a/pixels-core/include/writer/ColumnWriter.h
+++ b/pixels-core/include/writer/ColumnWriter.h
@@ -53,7 +53,7 @@ public:
     virtual bool decideNullsPadding(std::shared_ptr<PixelsWriterOption> writerOption) =0;
     virtual pixels::proto::ColumnChunkIndex getColumnChunkIndex();
     virtual std::shared_ptr<pixels::proto::ColumnChunkIndex> getColumnChunkIndexPtr();
-    virtual pixels::proto::ColumnEncoding getColumnChunkEncoding();
+    virtual pixels::proto::ColumnEncoding getColumnChunkEncoding() const ; 
     virtual void reset();
     virtual void flush() ;
     virtual void close() ;

--- a/pixels-core/include/writer/IntegerColumnWriter.h
+++ b/pixels-core/include/writer/IntegerColumnWriter.h
@@ -37,7 +37,7 @@ public:
     void newPixel() override;
     void writeCurPartLong(std::shared_ptr<ColumnVector> columnVector, long* values, int curPartLength, int curPartOffset);
     bool decideNullsPadding(std::shared_ptr<PixelsWriterOption> writerOption) override;
-    pixels::proto::ColumnEncoding getColumnChunkEncoding();
+    pixels::proto::ColumnEncoding getColumnChunkEncoding() const override;
 private:
     bool isLong; //current column type is long or int, used for the first pixel
     bool runlengthEncoding;


### PR DESCRIPTION
#62 
add const for function  getColumnChunkEncoding so that the derived classes can override it correctly.