### PR TITLE
[Issue #69] fix startOffset in StringColumnWriter

### DIFF
--- a/pixels-core/lib/writer/StringColumnWriter.cpp
+++ b/pixels-core/lib/writer/StringColumnWriter.cpp
@@ -38,7 +38,7 @@ void StringColumnWriter::flush(){
 }
 
 void StringColumnWriter::flushStarts() {
- int startsFieldOffset=outputStream->size();
+ int startsFieldOffset=outputStream->getWritePos();
  startsArray->add(startOffset);
  if(byteOrder==ByteOrder::PIXELS_LITTLE_ENDIAN) {
   for (int i=0;i<startsArray->size();i++) {


### PR DESCRIPTION
In StringColumnReader::readContent: l161
`int startsOffset = input->getInt();`
If you call ouputStream->size() in the function flush_start(), you will get 4096 instead of real start offset.
Then you will get a empty string.